### PR TITLE
RSDK-6618: Allow remapping of tensor names in vision mlmodel, transpose tensor image channels

### DIFF
--- a/services/mlmodel/mlmodel.go
+++ b/services/mlmodel/mlmodel.go
@@ -42,7 +42,7 @@ func TensorsToProto(ts ml.Tensors) (*servicepb.FlatTensors, error) {
 	for name, t := range ts {
 		tp, err := tensorToProto(t)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to convert tensor to proto message")
+			return nil, errors.Wrapf(err, "failed to convert tensor %q to proto message", name)
 		}
 		pbts.Tensors[name] = tp
 	}
@@ -67,6 +67,12 @@ func tensorToProto(t *tensor.Dense) (*servicepb.FlatTensor, error) {
 		ftpb.Tensor = &servicepb.FlatTensor_Uint8Tensor{
 			Uint8Tensor: &servicepb.FlatTensorDataUInt8{
 				Data: dataSlice,
+			},
+		}
+	case uint8:
+		ftpb.Tensor = &servicepb.FlatTensor_Uint8Tensor{
+			Uint8Tensor: &servicepb.FlatTensorDataUInt8{
+				Data: []uint8{dataSlice},
 			},
 		}
 	case []int16:
@@ -121,6 +127,12 @@ func tensorToProto(t *tensor.Dense) (*servicepb.FlatTensor, error) {
 				Data: dataSlice,
 			},
 		}
+	case float32:
+		ftpb.Tensor = &servicepb.FlatTensor_FloatTensor{
+			FloatTensor: &servicepb.FlatTensorDataFloat{
+				Data: []float32{dataSlice},
+			},
+		}
 	case []float64:
 		ftpb.Tensor = &servicepb.FlatTensor_DoubleTensor{
 			DoubleTensor: &servicepb.FlatTensorDataDouble{
@@ -128,7 +140,7 @@ func tensorToProto(t *tensor.Dense) (*servicepb.FlatTensor, error) {
 			},
 		}
 	default:
-		return nil, errors.Errorf("cannot turn underlying tensor data of type %T into proto message", dataSlice)
+		return nil, errors.Errorf("cannot turn underlying tensor data of type %T into proto message", data)
 	}
 	return ftpb, nil
 }

--- a/services/vision/mlvision/ml_model_test.go
+++ b/services/vision/mlvision/ml_model_test.go
@@ -91,15 +91,16 @@ func TestAddingIncorrectModelTypeToModel(t *testing.T) {
 	mlm, err := getTestMlModel(modelLocDetector)
 	test.That(t, err, test.ShouldBeNil)
 
-	nameMap := &sync.Map{}
-	classifier, err := attemptToBuildClassifier(mlm, nameMap)
+	inNameMap := &sync.Map{}
+	outNameMap := &sync.Map{}
+	classifier, err := attemptToBuildClassifier(mlm, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, classifier, test.ShouldNotBeNil)
 
 	err = checkIfClassifierWorks(ctx, classifier)
 	test.That(t, err, test.ShouldNotBeNil)
 
-	detector, err := attemptToBuildDetector(mlm, nameMap)
+	detector, err := attemptToBuildDetector(mlm, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, detector, test.ShouldNotBeNil)
 
@@ -111,8 +112,9 @@ func TestAddingIncorrectModelTypeToModel(t *testing.T) {
 	mlm, err = getTestMlModel(modelLocClassifier)
 	test.That(t, err, test.ShouldBeNil)
 
-	nameMap = &sync.Map{}
-	classifier, err = attemptToBuildClassifier(mlm, nameMap)
+	inNameMap = &sync.Map{}
+	outNameMap = &sync.Map{}
+	classifier, err = attemptToBuildClassifier(mlm, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, classifier, test.ShouldNotBeNil)
 
@@ -122,7 +124,7 @@ func TestAddingIncorrectModelTypeToModel(t *testing.T) {
 	mlm, err = getTestMlModel(modelLocClassifier)
 	test.That(t, err, test.ShouldBeNil)
 
-	detector, err = attemptToBuildDetector(mlm, nameMap)
+	detector, err = attemptToBuildDetector(mlm, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, detector, test.ShouldNotBeNil)
 
@@ -163,8 +165,9 @@ func TestNewMLDetector(t *testing.T) {
 	test.That(t, check.Outputs[1].Name, test.ShouldResemble, "category")
 	test.That(t, check.Outputs[0].Extra["labels"], test.ShouldNotBeNil)
 
-	nameMap := &sync.Map{}
-	gotDetector, err := attemptToBuildDetector(out, nameMap)
+	inNameMap := &sync.Map{}
+	outNameMap := &sync.Map{}
+	gotDetector, err := attemptToBuildDetector(out, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetector, test.ShouldNotBeNil)
 
@@ -188,8 +191,9 @@ func TestNewMLDetector(t *testing.T) {
 	outNL, err := tflitecpu.NewTFLiteCPUModel(ctx, &noLabelCfg, mlmodel.Named("myOtherMLDet"))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, outNL, test.ShouldNotBeNil)
-	nameMap = &sync.Map{}
-	gotDetectorNL, err := attemptToBuildDetector(outNL, nameMap)
+	inNameMap = &sync.Map{}
+	outNameMap = &sync.Map{}
+	gotDetectorNL, err := attemptToBuildDetector(outNL, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetectorNL, test.ShouldNotBeNil)
 	gotDetectionsNL, err := gotDetectorNL(ctx, pic)
@@ -238,8 +242,9 @@ func TestNewMLClassifier(t *testing.T) {
 	test.That(t, check.Outputs[0].Name, test.ShouldResemble, "probability")
 	test.That(t, check.Outputs[0].Extra["labels"], test.ShouldNotBeNil)
 
-	nameMap := &sync.Map{}
-	gotClassifier, err := attemptToBuildClassifier(out, nameMap)
+	inNameMap := &sync.Map{}
+	outNameMap := &sync.Map{}
+	gotClassifier, err := attemptToBuildClassifier(out, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifier, test.ShouldNotBeNil)
 
@@ -257,8 +262,9 @@ func TestNewMLClassifier(t *testing.T) {
 	outNL, err := tflitecpu.NewTFLiteCPUModel(ctx, &noLabelCfg, mlmodel.Named("myOtherMLClassif"))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, outNL, test.ShouldNotBeNil)
-	nameMap = &sync.Map{}
-	gotClassifierNL, err := attemptToBuildClassifier(outNL, nameMap)
+	inNameMap = &sync.Map{}
+	outNameMap = &sync.Map{}
+	gotClassifierNL, err := attemptToBuildClassifier(outNL, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifierNL, test.ShouldNotBeNil)
 	gotClassificationsNL, err := gotClassifierNL(ctx, pic)
@@ -300,8 +306,9 @@ func TestMoreMLDetectors(t *testing.T) {
 	test.That(t, check.Inputs[0].DataType, test.ShouldResemble, "float32")
 	test.That(t, len(check.Outputs), test.ShouldEqual, 4)
 
-	nameMap := &sync.Map{}
-	gotDetector, err := attemptToBuildDetector(outModel, nameMap)
+	inNameMap := &sync.Map{}
+	outNameMap := &sync.Map{}
+	gotDetector, err := attemptToBuildDetector(outModel, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotDetector, test.ShouldNotBeNil)
 
@@ -331,8 +338,9 @@ func TestMoreMLClassifiers(t *testing.T) {
 	test.That(t, check, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeNil)
 
-	nameMap := &sync.Map{}
-	gotClassifier, err := attemptToBuildClassifier(outModel, nameMap)
+	inNameMap := &sync.Map{}
+	outNameMap := &sync.Map{}
+	gotClassifier, err := attemptToBuildClassifier(outModel, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifier, test.ShouldNotBeNil)
 
@@ -359,8 +367,9 @@ func TestMoreMLClassifiers(t *testing.T) {
 	test.That(t, check, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeNil)
 
-	nameMap = &sync.Map{}
-	gotClassifier, err = attemptToBuildClassifier(outModel, nameMap)
+	inNameMap = &sync.Map{}
+	outNameMap = &sync.Map{}
+	gotClassifier, err = attemptToBuildClassifier(outModel, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, gotClassifier, test.ShouldNotBeNil)
 	gotClassifications, err = gotClassifier(ctx, pic)
@@ -433,8 +442,9 @@ func TestOneClassifierOnManyCameras(t *testing.T) {
 	out, err := tflitecpu.NewTFLiteCPUModel(ctx, &cfg, mlmodel.Named("testClassifier"))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, out, test.ShouldNotBeNil)
-	nameMap := &sync.Map{}
-	outClassifier, err := attemptToBuildClassifier(out, nameMap)
+	inNameMap := &sync.Map{}
+	outNameMap := &sync.Map{}
+	outClassifier, err := attemptToBuildClassifier(out, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, outClassifier, test.ShouldNotBeNil)
 	valuePanda, valueLion := classifyTwoImages(picPanda, picLion, outClassifier)
@@ -452,12 +462,14 @@ func TestMultipleClassifiersOneModel(t *testing.T) {
 	out, err := tflitecpu.NewTFLiteCPUModel(ctx, &cfg, mlmodel.Named("testClassifier"))
 	test.That(t, err, test.ShouldBeNil)
 
-	nameMap := &sync.Map{}
-	Classifier1, err := attemptToBuildClassifier(out, nameMap)
+	inNameMap := &sync.Map{}
+	outNameMap := &sync.Map{}
+	Classifier1, err := attemptToBuildClassifier(out, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 
-	nameMap = &sync.Map{}
-	Classifier2, err := attemptToBuildClassifier(out, nameMap)
+	inNameMap = &sync.Map{}
+	outNameMap = &sync.Map{}
+	Classifier2, err := attemptToBuildClassifier(out, inNameMap, outNameMap)
 	test.That(t, err, test.ShouldBeNil)
 
 	picPanda, err := rimage.NewImageFromFile(artifact.MustPath("vision/tflite/redpanda.jpeg"))

--- a/services/vision/mlvision/segmenter3d.go
+++ b/services/vision/mlvision/segmenter3d.go
@@ -9,6 +9,6 @@ import (
 )
 
 // TODO: RSDK-2665, build 3D segmenter from ML models.
-func attemptToBuild3DSegmenter(mlm mlmodel.Service, nameMap *sync.Map) (segmentation.Segmenter, error) {
+func attemptToBuild3DSegmenter(mlm mlmodel.Service, inNameMap, outNameMap *sync.Map) (segmentation.Segmenter, error) {
 	return nil, errors.New("cannot use model as a 3D segmenter: vision 3D segmenters from ML models are currently not supported")
 }


### PR DESCRIPTION
This update allows the remapping the tensor names that will allow most ONNX files to run 